### PR TITLE
feat: ワークルール振り返り回答時にSlack通知する

### DIFF
--- a/app/api/workrules/retrospective/route.ts
+++ b/app/api/workrules/retrospective/route.ts
@@ -1,6 +1,102 @@
 import { notionClient } from '@/lib/notionClient'
+import { slack } from '@/lib/slack'
 import { NextApiRequest } from 'next'
 import { NextResponse } from 'next/server'
+
+const generateSlackMessage = (message: string) => {
+  const header = {
+    type: 'header',
+    text: {
+      type: 'plain_text',
+      text: ':white_check_mark: ワークルールの振り返りが完了しました！',
+      emoji: true,
+    },
+  }
+  const context = {
+    type: 'context',
+    elements: [
+      {
+        type: 'plain_text',
+        text: '引き続き頑張っていきましょう！',
+        emoji: true,
+      },
+    ],
+  }
+  const unachievedRules = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '体現できなかったワークルールは以下の通りです :point_down:',
+      },
+    },
+    {
+      type: 'rich_text',
+      elements: [
+        {
+          type: 'rich_text_list',
+          style: 'bullet',
+          elements: [
+            {
+              type: 'rich_text_section',
+              elements: [
+                {
+                  type: 'text',
+                  text: 'item 1: ',
+                },
+                {
+                  type: 'emoji',
+                  name: 'basketball',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]
+  const actionsButtons = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '回答内容を確認するにはこちらをクリック :arrow_right:',
+      },
+      accessory: {
+        type: 'button',
+        text: {
+          type: 'plain_text',
+          text: '確認する',
+          emoji: true,
+        },
+        value: 'click_me_123',
+        url: 'https://google.com',
+        action_id: 'button-action',
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '体現度向上のためにアクションプランを設定しましょう :muscle:',
+      },
+      accessory: {
+        type: 'button',
+        text: {
+          type: 'plain_text',
+          text: '設定する',
+          emoji: true,
+        },
+        value: 'click_me_123',
+        url: 'https://google.com',
+        action_id: 'button-action',
+      },
+    },
+  ]
+  return {
+    blocks: [header, context, ...unachievedRules, ...actionsButtons],
+  }
+}
 
 export async function POST(request: Request) {
   const body = await request.json()
@@ -31,6 +127,8 @@ export async function POST(request: Request) {
         },
       },
     })
+    const message = generateSlackMessage('hogefuga')
+    await slack.sendMessage(message)
     return NextResponse.json(response)
   } catch (err) {
     throw NextResponse.json(err)

--- a/app/workrules/new/page.tsx
+++ b/app/workrules/new/page.tsx
@@ -78,11 +78,10 @@ export default function New() {
   const { showSnackbar } = useSnackbarContext()
 
   const onSubmit = async () => {
-    const unselectedRowIds = data
+    const unselectedRows = data
       .filter((row) => !selectedRowIds.includes(row.id))
-      .map((row) => row.id)
     await onSubmitAnswer({
-      unselectedRowIds,
+      unselectedRows,
     })
       .then(() => {
         showSnackbar?.('success', '回答を送信しました')

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -4,7 +4,10 @@ import { NextApiRequest, NextApiResponse } from 'next'
 export const slack = {
   sendMessage: async (message: IncomingWebhookSendArguments) => {
     const url = process.env.SLACK_WEBHOOK_URL
-    const webhook = new IncomingWebhook(url ?? '')
+    if (!url) {
+      throw 'SLACK_WEBHOOK_URL is not defined'
+    }
+    const webhook = new IncomingWebhook(url)
     await webhook.send(message)
   },
 }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -1,0 +1,10 @@
+import { IncomingWebhook, IncomingWebhookSendArguments } from '@slack/webhook'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+export const slack = {
+  sendMessage: async (message: IncomingWebhookSendArguments) => {
+    const url = process.env.SLACK_WEBHOOK_URL
+    const webhook = new IncomingWebhook(url ?? '')
+    await webhook.send(message)
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/material-nextjs": "^5.15.11",
         "@mui/x-data-grid": "^7.5.1",
         "@notionhq/client": "^2.2.15",
+        "@slack/webhook": "^7.0.2",
         "axios": "^1.7.2",
         "eslint-config-prettier": "^9.1.0",
         "next": "14.2.3",
@@ -1101,6 +1102,29 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
       "integrity": "sha512-qC/xYId4NMebE6w/V33Fh9gWxLgURiNYgVNObbJl2LZv0GUUItCcCqC5axQSwRaAgaxl2mELq1rMzlswaQ0Zxg==",
       "dev": true
+    },
+    "node_modules/@slack/types": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==",
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
+    "node_modules/@slack/webhook": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-7.0.2.tgz",
+      "integrity": "sha512-dsrO/ow6a6+xkLm/lZKbUNTsFJlBc679tD+qwlVTztsQkDxPLH6odM7FKALz1IHa+KpLX8HKUIPV13a7y7z29w==",
+      "dependencies": {
+        "@slack/types": "^2.9.0",
+        "@types/node": ">=18.0.0",
+        "axios": "^1.6.3"
+      },
+      "engines": {
+        "node": ">= 18",
+        "npm": ">= 8.6.0"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@mui/material-nextjs": "^5.15.11",
     "@mui/x-data-grid": "^7.5.1",
     "@notionhq/client": "^2.2.15",
+    "@slack/webhook": "^7.0.2",
     "axios": "^1.7.2",
     "eslint-config-prettier": "^9.1.0",
     "next": "14.2.3",


### PR DESCRIPTION
# やったこと
- SSIA
- リンク先が未完成な箇所は仮置きです

# 目的
- Slackに通知させる方が回答内容が分かりやすいので

# 関連issue

# 影響範囲